### PR TITLE
Set hostname of web request as fallback instead of localhost

### DIFF
--- a/.github/workflows/webui-build.yml
+++ b/.github/workflows/webui-build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: 🔧 Install, build and test
         run: |
           npm install
-          npm run build --mode production
+          npm run build
           npm test
       - name: 🚀 Deploying on 'builds_${{ env.GITHUB_REF_SLUG }}'
         uses: JamesIves/github-pages-deploy-action@3.7.1

--- a/.github/workflows/webui-build.yml
+++ b/.github/workflows/webui-build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: 🔧 Install, build and test
         run: |
           npm install
-          npm run build
+          npm run build --mode production
           npm test
       - name: 🚀 Deploying on 'builds_${{ env.GITHUB_REF_SLUG }}'
         uses: JamesIves/github-pages-deploy-action@3.7.1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # webui
 
+| Branch | Status |
+|-|-|
+| Master | ![WebUI build Master](https://github.com/project-alice-assistant/webui/workflows/WebUI%20build/badge.svg?branch=master) |
+| 1.0.0-b5 | ![WebUI build 1.0.0-b5](https://github.com/project-alice-assistant/webui/workflows/WebUI%20build/badge.svg?branch=1.0.0-b5) |
+
 ## Project setup
 ```
 npm install

--- a/src/components/js/connect.js
+++ b/src/components/js/connect.js
@@ -17,7 +17,7 @@ export default {
 		if (this.remember === 'true') this.remember = true
 		if (this.remember === 'false') this.remember = false
 
-		this.ip = localStorage.getItem('host') || '127.0.0.1'
+		this.ip = localStorage.getItem('host') || window.location.hostname || '127.0.0.1'
 		this.port = localStorage.getItem('apiPort') || 5001
 
 		if (localStorage.getItem('skillsTourCompleted')) {


### PR DESCRIPTION
A new user expects the default value of ip and port to be correct if it is already given. My expectation why it didn't autoconnect was that I could enter an alternative host. Since the webserver and alice instance are on the same machine, I thought localhost was alright and on first try I didn't get why it wouldn't work. I had to get help from the community to realize I had to enter a hostname or ip from the perspective of the web client. But since its the same machine we can just use the hostname of the initial webrequest as default value.